### PR TITLE
optionally pass the destinationSchema for an AB connection

### DIFF
--- a/ddpui/api/client/user_org_api.py
+++ b/ddpui/api/client/user_org_api.py
@@ -186,6 +186,20 @@ def post_organization_warehouse(request, payload: OrgWarehouseSchema):
     )
     logger.info("created destination having id " + destination["destinationId"])
 
+    # prepare the dbt credentials from airbyteConfig
+    dbtCredenials = None
+    if payload.wtype == 'postgres':
+        dbtCredenials = {
+            "host": payload.airbyteConfig['host'],
+            "port": payload.airbyteConfig['port'],
+            "username": payload.airbyteConfig['username'],
+            "password": payload.airbyteConfig['password'],
+            "database": payload.airbyteConfig['database'],
+        }
+
+    if payload.wtype == 'bigquery':
+        dbtCredenials = payload.airbyteConfig['credentials_json']
+
     warehouse = OrgWarehouse(
         org=orguser.org,
         wtype=payload.wtype,
@@ -193,7 +207,7 @@ def post_organization_warehouse(request, payload: OrgWarehouseSchema):
         airbyte_destination_id=destination["destinationId"],
     )
     credentials_lookupkey = secretsmanager.save_warehouse_credentials(
-        warehouse, payload.dbtCredentials
+        warehouse, dbtCredenials
     )
     warehouse.credentials = credentials_lookupkey
     warehouse.save()

--- a/ddpui/ddpairbyte/airbyte_service.py
+++ b/ddpui/ddpairbyte/airbyte_service.py
@@ -267,6 +267,9 @@ def create_connection(workspace_id, connection_info: schema.AirbyteConnectionCre
         "geography": "auto",
         "name": connection_info.name,
     }
+    if connection_info.destinationSchema:
+        payload["namespaceDefinition"] = "customformat"
+        payload["namespaceFormat"] = connection_info.destinationSchema
     if connection_info.normalize:
         payload["operations"] = [
             {

--- a/ddpui/ddpairbyte/schema.py
+++ b/ddpui/ddpairbyte/schema.py
@@ -46,6 +46,7 @@ class AirbyteConnectionCreate(Schema):
     name: str
     sourceId: str
     destinationId: str = None
+    destinationSchema: str = None
     streamNames: list
     normalize: bool = False
 

--- a/ddpui/models/org.py
+++ b/ddpui/models/org.py
@@ -72,4 +72,3 @@ class OrgWarehouseSchema(Schema):
     wtype: str
     destinationDefId: str
     airbyteConfig: dict
-    dbtCredentials: dict


### PR DESCRIPTION
if the `destinationSchema` is passed to `/airbyte/connections` then pass it on to Airbyte via `namespaceFormat` and set `namespaceDefinition` to `customformat`